### PR TITLE
Improve character count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual env
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+termcolor==1.1.0
+tweepy==3.5.0
+twitter-text-python==1.1.0


### PR DESCRIPTION
Hi @pacocp,

I've improved character count in your post tweet function. 

In the [Twitter API docs](https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update), they explain the following:

> The text of the status update, typically up to 140 characters. URL encode as necessary. t.co link wrapping may affect character counts. There are some special commands in this field to be aware of. For instance, preceding a message with “D ” or “M ” and following it with a screen name can create a Direct Message to that user if the relationship allows for it. See the ‘enable_dm_commands’ parameter for information on disabling Direct Message creation to allow any text to be created as a Tweet.

What does that mean? That URLs counts only a maximum number of characters in a tweet. To know how many characters does a URL count, we have to read [this page of the docs](https://developer.twitter.com/en/docs/basics/tco):
> If you are using the opt-in features, all URLs regardless of length should be considered to be the maximum length reported to you by `help/configuration`.

So I've added added a new function, `get_tweet_len`, that only counts URLs with the count returned by [GET help/configuration](https://developer.twitter.com/en/docs/developer-utilities/configuration/api-reference/get-help-configuration) API call.

I've also added a gitignore and a requirements.txt file.

Best regards,
Marta